### PR TITLE
Fix

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -3,5 +3,5 @@
   <% } else { %>
   &copy; <%= new Date().getFullYear() %> <%= config.title %>
   <% } %>
-      with help from <a href="http://zespia.tw/hexo/" target="_blank">Hexo</a> and <a href="http://getbootstrap.com/" target="_blank">Twitter Bootstrap</a>. Theme by <a href="http://github.com/wzpan/hexo-theme-freemind/">Freemind</a>.    
+      with help from <a href="http://hexo.io/" target="_blank">Hexo</a> and <a href="http://getbootstrap.com/" target="_blank">Twitter Bootstrap</a>. Theme by <a href="http://github.com/wzpan/hexo-theme-freemind/">Freemind</a>.    
 </p>

--- a/layout/_partial/post/comment.ejs
+++ b/layout/_partial/post/comment.ejs
@@ -3,7 +3,7 @@
   <h2 class="title"><%= __('comment') %></h2>
 
   <% if(theme.duoshuo_shortname) { %>
-  	 <div class="ds-thread" data-thread-key="<%= page.permalink %>" data-title="<%= page.title %>" data-url="<%= page.permalink %>"></div>  
+  	 <div class="ds-thread" data-thread-key="<%- page.path %>" data-title="<%- page.title %>" data-url="<%- page.permalink %>"></div>  
   <% } else if(config.disqus_shortname) { %>
   	 <div id="disqus_thread">
      <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
1. 根据多说代码参数说明：“data-thread-key中:和,即冒号和逗号有特别的用途，请不要使用url或其他有这两个符号的内容作为data-thread-key”。修改data-thread-key变量为page.path。
2. 修改多说代码变量<%= VARIABLE_NAME %>为<%- VARIABLE_NAME %>，防止转义。
3. 更新Hexo官网链接。