### PR TITLE
only display read_more button if there's more to display

### DIFF
--- a/layout/_partial/post/entry.ejs
+++ b/layout/_partial/post/entry.ejs
@@ -10,9 +10,10 @@
 	<% } %>
 	<% if (item.excerpt && index) { %>
 		<%- item.excerpt %>
+		<!-- only display read_more button if there's more to display -->
+		<a type="button" href="<%- config.root %><%- item.path %>#more" class="btn btn-default more"><%= __('read_more') %></a>
 	<% } else { %>
 		<%- item.content %>
 	<% } %>
 	</div>
-  <a type="button" href="<%- config.root %><%- item.path %>#more" class="btn btn-default more"><%= __('read_more') %></a>
 </div>


### PR DESCRIPTION
Corrects an issue where the _"Read more"_ button was always displayed even if there was no more to display in a post.