### PR TITLE
prevent hexo from generating redundant /html tag

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,3 @@
-<!DOCTYPE HTML>
-<html>
 <head>
   <meta charset="utf-8">
   <%

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,15 +1,17 @@
+<!DOCTYPE HTML>
+<html>
 <%- partial('_partial/head') %>
- <body>  
+<body>
   <%- partial('_partial/navigation') %>
   <div class="container">
-  	<div class="content">
-    	 <%- body %>
-	</div>
+    <div class="content">
+      <%- body %>
+    </div>
   </div>
   <div class="container-narrow">
-  <footer> <%- partial('_partial/footer') %> </footer>
-</div> <!-- container-narrow -->
+    <footer> <%- partial('_partial/footer') %> </footer>
+  </div> <!-- container-narrow -->
   <%- partial('_partial/search') %>
   <%- partial('_partial/after_footer') %>
 </body>
-   </html>
+</html>


### PR DESCRIPTION
Fixed an issue that hexo generated redundant html close tag. See screenshot below:

![image](https://user-images.githubusercontent.com/1393989/59970756-c1c91e80-95a0-11e9-8364-41f5947fb22a.png)

To fix this issue, the `html` tag in "head.ejs" should be moved to "layout.ejs".

Thanks.
