### PR TITLE
use url_for() instead of 'config.root + post.link'

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -74,7 +74,7 @@
 		   	  <span class="title link"><a href="<%- item.link %>" target="_blank" <% if (item.description) { %> title="<%= item.description %>" <% } %>><%= item.link %></a></span>
 		   <% } %>
 		<% } else { %>
-		   <span class="title"><a href="<%- config.root %><%- item.path %>" <% if (item.description) { %> title="<%= item.description %>" <% } %>><%= item.title %></a></span>
+		   <span class="title"><a href="<%- url_for(item.path) %>" <% if (item.description) { %> title="<%= item.description %>" <% } %>><%= item.title %></a></span>
 		<% } %>
 		</li>			
 		<% }); %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -36,10 +36,10 @@
   <% } %>
 
   <% if (theme.rss){ %>
-    <link rel="alternative" href="<%- config.root %><%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
+    <link rel="alternative" href="<%- url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
   <% if (theme.favicon){ %>
-    <link href="<%- config.root %><%- theme.favicon %>" rel="icon">
+    <link href="<%- url_for(theme.favicon) %>" rel="icon">
   <% } %>
 
   <!-- CSS -->

--- a/layout/_partial/index_pagination.ejs
+++ b/layout/_partial/index_pagination.ejs
@@ -2,7 +2,7 @@
 <ul class="pagination">
 	 <% if (page.prev || page.next) { %>
 		<% if (page.prev){ %>
-    	<li class="prev"><a href="<%- config.root %><%- page.prev_link %>" class="alignleft prev"><i class="fa fa-arrow-circle-o-left"></i> <%= __('prev') %></a></li>
+		<li class="prev"><a href="<%- url_for(page.prev_link) %>" class="alignleft prev"><i class="fa fa-arrow-circle-o-left"></i> <%= __('prev') %></a></li>
   		<% } else { %>
           <li class="prev disabled"><a><i class="fa fa-arrow-circle-o-left"></i><%= __('prev') %></a></li>
         <% } %>
@@ -10,7 +10,7 @@
         <li><a href="<%- config.root %>"><i class="fa fa-home"></i>Home</a></li>
 
 		<% if (page.next){ %>
-		   <li class="next"> <a href="<%- config.root %><%- page.next_link %>" class="alignright next"><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a> </li>          
+		   <li class="next"> <a href="<%- url_for(page.next_link) %>" class="alignright next"><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a> </li>
         <% } else { %>
           <li class="next disabled"><a><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a></li>
         <% } %>

--- a/layout/_partial/navigation.ejs
+++ b/layout/_partial/navigation.ejs
@@ -11,7 +11,7 @@
 		<ul class="nav navbar-nav">
 		  <% theme.menu.forEach(function(m){ %>
 		  <li>
-			<a href="<%- config.root %><%- m.url %>" title="<%- m.intro %>">
+			<a href="<%- url_for(m.url) %>" title="<%- m.intro %>">
 			  <i class="<%- m.icon %>"></i><%- m.title %>
 			</a>
 		  </li>

--- a/layout/_partial/post/category.ejs
+++ b/layout/_partial/post/category.ejs
@@ -1,7 +1,7 @@
   <%
   var cats = [];
   item.categories.forEach(function(cat){
-    cats.push('<li><a href="' + config.root + cat.path + '">' + cat.name + '<span>' + cat.length  + '</span></a></li>');
+    cats.push('<li><a href="' + url_for(cat.path) + '">' + cat.name + '<span>' + cat.length  + '</span></a></li>');
   });
   %>
   <li>

--- a/layout/_partial/post/entry.ejs
+++ b/layout/_partial/post/entry.ejs
@@ -2,9 +2,9 @@
   <div class="row">
 	<% if (item.feature ) { %>
            <% if (config.post_asset_folder){ %>
-  	      <div class="thumbnail"><a href="<%- config.root %><%= item.path %>"><img src="<%= item.path %><%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
+              <div class="thumbnail"><a href="<%= url_for(item.path) %>"><img src="<%= item.path %><%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
            <% } else { %>
-              <div class="thumbnail"><a href="<%- config.root %><%= item.path %>"><img src="<%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
+              <div class="thumbnail"><a href="<%= url_for(item.path) %>"><img src="<%= item.feature %>" alt="<%= item.title %>"  class="nofancybox"></a>
            <% } %>
 		</div>
 	<% } %>
@@ -14,5 +14,5 @@
 		<%- item.content %>
 	<% } %>
 	</div>
-  <a type="button" href="<%- config.root %><%- item.path %>#more" class="btn btn-default more"><%= __('read_more') %></a>
+  <a type="button" href="<%- url_for(item.path) %>#more" class="btn btn-default more"><%= __('read_more') %></a>
 </div>

--- a/layout/_partial/post/pagination.ejs
+++ b/layout/_partial/post/pagination.ejs
@@ -2,15 +2,15 @@
 <ul class="pagination">
 	 <% if (page.prev || page.next) { %>
 		<% if (page.prev){ %>		
-    	<li class="prev"><a href="<%- config.root %><%- page.prev.path %>" class="alignleft prev"><i class="fa fa-arrow-circle-o-left"></i><%= __('prev') %></a></li>
+		<li class="prev"><a href="<%- url_for(page.prev.path) %>" class="alignleft prev"><i class="fa fa-arrow-circle-o-left"></i><%= __('prev') %></a></li>
   		<% } else { %>
           <li class="prev disabled"><a><i class="fa fa-arrow-circle-o-left"></i><%= __('prev') %></a></li>
         <% } %>
 
-        <li><a href="<%- config.root %><%- theme.menu[0].url %>"><i class="fa fa-archive"></i>Archive</a></li>
+        <li><a href="<%- url_for(theme.menu[0].url) %>"><i class="fa fa-archive"></i>Archive</a></li>
 
 		<% if (page.next){ %>
-		   <li class="next"><a href="<%- config.root %><%- page.next.path %>" class="alignright next"><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a></li>         
+          <li class="next"><a href="<%- url_for(page.next.path) %>" class="alignright next"><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a></li>
         <% } else { %>
           <li class="next disabled"><a><%= __('next') %><i class="fa fa-arrow-circle-o-right"></i></a></li>
         <% } %>

--- a/layout/_partial/post/tag.ejs
+++ b/layout/_partial/post/tag.ejs
@@ -1,7 +1,7 @@
   <%
   var tags = [];
   item.tags.forEach(function(tag){
-    tags.push('<li><a href="' + config.root + tag.path + '">' + tag.name + '<span>' + tag.length  + '</span></a></li>');
+    tags.push('<li><a href="' + url_for(tag.path) + '">' + tag.name + '<span>' + tag.length  + '</span></a></li>');
   });
   %>
   <%- tags.join(' ') %>

--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -9,7 +9,7 @@
 	<!-- display as entry -->	
 		<h3 class="title">
 			<div class="date"> <%= item.date.format(config.date_format) %> </div>
-			<div class="article-title"><a href="<%- config.root %><%- item.path %>" <% if(item.description) { %>title="<%= item.description %>"<% } %>><%= item.title %></a></div>						
+			<div class="article-title"><a href="<%- url_for(item.path) %>" <% if(item.description) { %>title="<%= item.description %>"<% } %>><%= item.title %></a></div>
 		</h3>
 	<% } else { %>
 		<div class="page-header <% if (theme.inverse){ %>page-header-inverse <% } %>">		

--- a/layout/_partial/post/title_top.ejs
+++ b/layout/_partial/post/title_top.ejs
@@ -9,7 +9,7 @@
 	<!-- display as entry -->	
 		<h3 class="title-top">
 			<div class="date"> <%= item.date.format(config.date_format) %> </div>
-			<div class="article-title"><a href="<%- config.root %><%- item.path %>" <% if(item.description) { %>title="<%= item.description %>"<% } %> class="article-title-text"><%= item.title %></span></a><span class="badge"><%= __('top') %></div>						
+			<div class="article-title"><a href="<%- url_for(item.path) %>" <% if(item.description) { %>title="<%= item.description %>"<% } %> class="article-title-text"><%= item.title %></span></a><span class="badge"><%= __('top') %></div>
 		</h3>
 	<% } else { %>
 		<div class="page-header <% if (theme.inverse){ %>page-header-inverse <% } %>">		

--- a/layout/_widget/category.ejs
+++ b/layout/_widget/category.ejs
@@ -3,7 +3,7 @@
 		<h4><%= __('categories') %></h4>
 		<ul class="tag_box inline list-unstyled">
 		<% site.categories.sort('name').each(function(item){ %>
-			<li><a href="<%- config.root %><%- item.path %>"><%= item.name %><span><%= item.posts.length %></span></a></li>
+			<li><a href="<%- url_for(item.path) %>"><%= item.name %><span><%= item.posts.length %></span></a></li>
 		<% }); %>
 		</ul>
 	</div>

--- a/layout/_widget/recent_posts.ejs
+++ b/layout/_widget/recent_posts.ejs
@@ -4,7 +4,7 @@
   <ul class="entry list-unstyled">
     <% site.posts.sort('date', -1).limit(5).each(function(post){ %>
       <li>
-        <a href="<%= config.root %><%= post.path %>" <% if (post.description) { %> title="<%= post.description %>" <% } %>><i class="fa fa-file-o"></i><%= truncate(post.title, 25) %></a>
+        <a href="<%= url_for(post.path) %>" <% if (post.description) { %> title="<%= post.description %>" <% } %>><i class="fa fa-file-o"></i><%= truncate(post.title, 25) %></a>
       </li>
     <% }); %>
   </ul>

--- a/layout/_widget/tagcloud.ejs
+++ b/layout/_widget/tagcloud.ejs
@@ -3,7 +3,7 @@
 		<h4><%= __('tagcloud') %></h4>
 		<ul class="tag_box inline list-unstyled">		
 		<% site.tags.random().limit(20).each(function(item){ %>
-			<li><a href="<%- config.root %><%- item.path %>"><%= item.name %><span><%= item.posts.length %></span></a></li>
+			<li><a href="<%- url_for(item.path) %>"><%= item.name %><span><%= item.posts.length %></span></a></li>
 		<% }); %>
 		<% if (site.tags.length > 20) { %>
 		   <li><a href="/tags">...<span><%= site.tags.length %></span></a></li>

--- a/layout/categories.ejs
+++ b/layout/categories.ejs
@@ -29,7 +29,7 @@
 
 		        <% site.posts.sort('date', -1).forEach(function(it){ %>
 			        <% if (it.categories.length == 1 && it.categories.data[0]._id == item._id){ %>
-		   	        <li class="listing-item"><a href="<%= config.root %><%= it.path %>" <% if (it.description) { %> title="<%= it.description %>" <% } %>><%= it.title %></a></li>
+                    <li class="listing-item"><a href="<%= url_for(it.path) %>" <% if (it.description) { %> title="<%= it.description %>" <% } %>><%= it.title %></a></li>
 			        <% } %>
 		        <% }); %>
 		   </ul>

--- a/layout/tags.ejs
+++ b/layout/tags.ejs
@@ -31,7 +31,7 @@
 	      <% if (it.tags.length >= 1) { %>
 		      <% it.tags.data.forEach(function(data){ %>
 			    <% if (data._id == item._id) { %>
-   	   	   	       <li class="listing-item"><a href="<%= config.root %><%= it.path %>" <% if (it.description) { %> title="<%= it.description %>" <% } %>><%= it.title %></a></li>
+                  <li class="listing-item"><a href="<%= url_for(it.path) %>" <% if (it.description) { %> title="<%= it.description %>" <% } %>><%= it.title %></a></li>
 				<% } %>
 		      <% }); %>
 		  <% } %>


### PR DESCRIPTION
<%- config.root %><%- post.link -> may introduce duplicate '/' at the beginning of an URL, leading to invalid URLs such as "//post-name" which is considered as "http://post-name" by the browser.

This is because the post permalink filter adds a preceding '/' to post.link and config.root may be '/'.

According to https://hexo.io/zh-cn/docs/helpers.html, we should use url_for(post.link) rather than config.root + path.