### PR TITLE
Do not show slogan if the user does not specify it

### DIFF
--- a/layout/_partial/post/slogan.ejs
+++ b/layout/_partial/post/slogan.ejs
@@ -1,4 +1,6 @@
+<% if (theme.slogan) { %>
 <div class="slogan">
       <i class="fa fa-heart"></i>
       <%= theme.slogan %>
-</div>    
+</div>
+<% } %>


### PR DESCRIPTION
Enables the user to remove the slogan by setting it as empty in the config.