### PR TITLE
add an option to show h2 and h3 titles in excerpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ slogan: Yet another bootstrap theme.
 
 theme: bootstrap
 inverse: true
+# whether to show h2 and h3 titles in excerpts
+show_title_in_excerpt: false
 
 menu:
   - title: Archives

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,8 @@ slogan: "Yet another bootstrap theme."
 
 theme: cerulean
 inverse: true
+# whether to show h2 and h3 titles in excerpts
+show_title_in_excerpt: false
 
 menu:
   - title: Archives

--- a/layout/_partial/post/entry.ejs
+++ b/layout/_partial/post/entry.ejs
@@ -1,4 +1,8 @@
+<% if (theme.show_title_in_excerpt) { %>
+<div class="entry-show-title">
+<% } else { %>
 <div class="entry">
+<% } %>
   <div class="row">
 	<% if (item.feature ) { %>
            <% if (config.post_asset_folder){ %>

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -375,11 +375,11 @@ h4 {
    entry
    ========================================================================== */
 
-.page .entry{
+.page .entry, .page .entry-show-title{
   padding-top: 10px 0;
 }
 
-.page .entry .row{
+.page .entry .row, .page .entry-show-title .row{
   padding-left: 20px;
   padding-right: 5px;
 }
@@ -393,11 +393,11 @@ h4 {
   display:block; overflow: hidden; width: 0; height: 0;
 }
 
-.page .entry .col-md-8{
+.page .entry .col-md-8, .page .entry-show-title .col-md-8{
   margin: 10px 0;
 }
 
-.page .entry .thumbnail{
+.page .entry .thumbnail, .page .entry-show-title .thumbnail{
   margin: 10px;
 }
 


### PR DESCRIPTION
add an option to show h2 and h3 titles in excerpts

Example: https://ring0.me/
Previously, the h2 and h3 titles disappear in excerpts. I think a user should be able to enable the titles in excerpts (default it is disabled).