### PR TITLE
support each post/page to specify whether to enable comments

### DIFF
--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -1,1 +1,3 @@
+<% if (!page.hasOwnProperty('comment')) { page.comment = false; } %>
+
 <%- partial('_partial/article', {item: page, post: false}) %>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -1,3 +1,3 @@
-<% page.comment = true; %>
+<% if (!page.hasOwnProperty('comment')) { page.comment = true; } %>
 
 <%- partial('_partial/article', {item: page, post: true}) %>


### PR DESCRIPTION
Currently, all posts enable comments and all pages disable comments.

This patch supports each post/page to specify whether to enable comments according to the "comments" attribute in the page header.

If the attribute "comments" does not exist, posts enable comments and pages disable comments by default.